### PR TITLE
Revisão da documentação + Melhora no rastreamento de falhas

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ php artisan workflow:sync --path=meu/caminho/pro/backup.json
 ```
 No caso da sincronização por diretório, o comando restaura os arquivos de .json mais recentemente modificados.
 
-### 5. **Listando as definições de workflows**
+### 6. **Listando as definições de workflows**
 
 Para listar as definições de workflow, utilize o método `Workflow::obterTodosWorkflowDefinitions`. Este método retorna todas as definições de workflow presentes no banco de dados.
 
@@ -159,7 +159,7 @@ $workflowDefinitions = Workflow::obterTodosWorkflowDefinitions();
 
 Com os dados retornados, você pode exibir o JSON formatado ou a imagem gerada do workflow na interface do usuário.
 
-### 6. **Criando um objeto de workflow**
+### 7. **Criando um objeto de workflow**
 
 Para instanciar um novo objeto de workflow baseado em uma definição existente, utilize o método `Workflow::criarWorkflowObject`. Ele inicializa o objeto no estado inicial definido pela configuração.
 
@@ -167,7 +167,7 @@ Para instanciar um novo objeto de workflow baseado em uma definição existente,
 $WorkflowObject = Workflow::criarWorkflowObject('pull_requests');
 ```
 
-### 7. **Exibindo um objeto de workflow**
+### 8. **Exibindo um objeto de workflow**
 
 Para exibir um objeto de workflow em uma view, utilize o método `Workflow::obterDadosDoObjeto`. Este método retorna os dados estruturados do objeto, incluindo sua definição, transições, formulários, título, atividades e submissões de formulário.
 
@@ -183,7 +183,7 @@ $activities = $workflowObjectData['activities'];
 $formSubmissions = $workflowObjectData['formSubmissions'];
 ```
 
-### 8. **Exibindo todos os objetos de uma definição**
+### 9. **Exibindo todos os objetos de uma definição**
 
 Para exibir todos os objetos de uma definição de workflow, utilize o método `Workflow::listarWorkflowsdaDefinition`. Este método retorna os objetos de workflow, as transições daquela definição e a própria definição
 
@@ -195,7 +195,7 @@ $workflowTransitions = $workflowsToDisplay['workflowsTransitions'];
 $workflowDefinition = $workflowsToDisplay['workflowDefinition'];
 ```
 
-### 9. **Exibindo todos os objetos criados pelo usuário**
+### 10. **Exibindo todos os objetos criados pelo usuário**
 
 Para exibir todos os objetos criados pelo usuário, utilize o método `Workflow::listarWorkflowsdoUser`. É possível passar um id de usuário como parâmetro, mas se não for fornecido, será utilizado o id do usuário autenticado no sistema. O método retorna os objetos de workflow e os dados do objeto, incluindo estado do dele e sua definição de workflow
 
@@ -206,7 +206,7 @@ $workflowObjects = $workflowsToDisplay['workflows'];
 $workflowData = $workflowsToDisplay['workflowData'];
 ```
 
-### 10. **Gerenciando transições de estado**
+### 11. **Gerenciando transições de estado**
 
 Utilize o método `Workflow::aplicarTransition` para mudar o estado de um objeto de workflow com base nas transições definidas.
 
@@ -216,7 +216,7 @@ Workflow::aplicarTransition($workflowObjectId, 'tr_opened_in_review');
 
 Esse método verifica se a transição é válida no estado atual antes de aplicá-la.
 
-### 11. **Apagando um objeto de workflow**
+### 12. **Apagando um objeto de workflow**
 
 Para excluir um objeto, utilize o método `Workflow::deletarWorkflow`.
 
@@ -224,7 +224,7 @@ Para excluir um objeto, utilize o método `Workflow::deletarWorkflow`.
 Workflow::deletarWorkflow($workflowObjectId);
 ```
 
-### 12. **Enviando um formulário**
+### 13. **Enviando um formulário**
 
 Para fazer a submissão de um formulário de um objeto de workflow, utilize o método `Workflow::enviarFormulario`
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ Para excluir uma definição, utilize o método `Workflow::deletarDefinicaodeWor
 Workflow::deletarDefinicaodeWorkflow($definitionName);
 ```
 
+### 5. **Restaurando uma definição de workflow**
+
+Ao gerar o backup de uma definição, é possível modificá-la através do mesmo e salvar as alterações, ou restaurar versões antigas através do comando `workflow:sync`. 
+O comando pode receber também um caminho na option `--path`, de forma a informar o caminho do arquivo ou diretório em que os .json das definições estão salvos. No caso da option não especificada, o diretório observado é o definido em `WORKFLOW_STORAGE_PATH` no arquivo .env (ou em storage/app/workflowsJson, o diretório padrão definido no arquivo de config)
+
+Dessa forma:
+```bash
+php artisan workflow:sync
+
+php artisan workflow:sync --path=meu/caminho/pro/diretório
+
+php artisan workflow:sync --path=meu/caminho/pro/backup.json
+```
+No caso da sincronização por diretório, o comando restaura os arquivos de .json mais recentemente modificados.
+
 ### 5. **Listando as definições de workflows**
 
 Para listar as definições de workflow, utilize o método `Workflow::obterTodosWorkflowDefinitions`. Este método retorna todas as definições de workflow presentes no banco de dados.

--- a/src/Console/Commands/WorkflowSync.php
+++ b/src/Console/Commands/WorkflowSync.php
@@ -32,6 +32,21 @@ class WorkflowSync extends Command
         $this->info('Sicnronizando workflows do caminho: ' . $path);
 
         // Chama o serviço de sincronizar no caminho especificado
-        app(WorkflowSyncService::class)->workflow_sync($path);
+        $result = app(WorkflowSyncService::class)->workflow_sync($path);
+
+        // Caso a sincronização tenha sido bem sucedida
+        if($result)
+        {
+            $this->line('Sincronização bem sucedida !');
+        }
+
+        // Se a sincronização falhar
+        else
+        {
+            $this->line('Falha ao sincronizar -- Caminho não é diretório nem arquivo existente!');
+        }
+
+        // Retorna (para uso dentro do código, como por exemplo em WorkflowBackupController.php, l:224)
+        return $result;
     }
 }

--- a/src/Http/Controllers/WorkflowBackupController.php
+++ b/src/Http/Controllers/WorkflowBackupController.php
@@ -221,9 +221,18 @@ class WorkflowBackupController extends Controller
         $filepath = $file_dir . '/' . $filename . '.json';
     
         // Chama o comando 'workflow:sync', passando o caminho desejado como option {--path}
-        Artisan::call('workflow:sync', ['--path' => $filepath]);
+        $result = Artisan::call('workflow:sync', ['--path' => $filepath]);
 
         // Retorna uma mensagem de sucesso.
-        return redirect()->back()->with('alert-success','Backup ' . $filename . ' restaurado com sucesso');
+        if($result)
+        {   
+            return redirect()->back()->with('alert-success','Backup ' . $filename . ' restaurado com sucesso');
+        }
+
+        // Mensagem de erro
+        else
+        {
+            return redirect()->back()->with('alert-danger','O caminho indicado: ' . $filename . ' não representa um diretório nem um arquivo existente.');
+        }
     }
 }

--- a/src/Services/WorkflowSyncService.php
+++ b/src/Services/WorkflowSyncService.php
@@ -17,10 +17,10 @@ class WorkflowSyncService
         // Recupera a definição do workflow salva no backup (em formato .json)
         $json_encoded = file_get_contents($filepath);
 
-        // Decodifica par aum array associativo
+        // Decodifica para um array associativo
         $decoded_json = json_decode($json_encoded, true);
 
-        // Busca a definição eplo nome e atualiza caso exita.
+        // Busca a definição pelo nome e atualiza caso exita.
         // Se não, cria uma nova definição com as informações do arquivo
         WorkflowDefinition::updateOrCreate(
             ['name' => $decoded_json['name']], 
@@ -62,8 +62,9 @@ class WorkflowSyncService
                     $most_recent_updt[$curr_def] = $filepath;
                 }
 
-                // Se existe, e o tempo de modificação do elemento contido no vetor for menor que o do arquivo atual
-                //(significa que a última modificação do contido foi anterior à do arquivo atual), faz a substituição
+                /* 
+                    Se existe, e o tempo de modificação do elemento contido no vetor for menor que o do arquivo atual (significa que a última modificação do contido foi anterior à do arquivo atual), faz a substituição
+                */
                 elseif(filemtime($most_recent_updt[$curr_def]) < filemtime($filepath))
                 {
                     $most_recent_updt[$curr_def] = $filepath;
@@ -83,7 +84,7 @@ class WorkflowSyncService
      * @param string $path
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function workflow_sync(string $path)
+    public function workflow_sync(string $path): bool
     {   
         // Caso seja um diretório
         if(is_dir($path))
@@ -97,10 +98,10 @@ class WorkflowSyncService
             $this->sync_file($path);
         }
 
-        // Mensagem de erro
-        else
-        {
-            return redirect()->back()->with('alert-danger','O caminho indicado: ' . $path . ' não representa um diretório nem um arquivo existente.');
-        }
+        // Retorna falso caso o caminho passado seja inválido
+        else {return false;}
+
+        // Retorna verdadeiro caso o caminho passado seja válido (e tenha sincronizado normalmente)
+        return true;
     }
 }


### PR DESCRIPTION
Documentação revisada (alguns erros de ortografia corrigidos + Modificação no README), além de algumas mudanças na estrutura do WorkflowSyncService e do WorkflowSync para que tanto no uso dentro do código quanto para bash o 'workflow:sync' exiba uma mensagem de falha ou sucesso na sincronização.